### PR TITLE
remove-trailing-spaces 1.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/remove-trailing-spaces/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,13 @@
+## Documentation
+
+You can see below the API reference of this module.
+
+### `removeTrailingSpaces(input)`
+Remove the trailing spaces from a string.
+
+#### Params
+- **String** `input`: The input string.
+
+#### Return
+- **String** The output string.
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-## remove-trailing-spaces [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/remove-trailing-spaces.svg)](https://travis-ci.org/IonicaBizau/remove-trailing-spaces/) [![Version](https://img.shields.io/npm/v/remove-trailing-spaces.svg)](https://www.npmjs.com/package/remove-trailing-spaces) [![Downloads](https://img.shields.io/npm/dt/remove-trailing-spaces.svg)](https://www.npmjs.com/package/remove-trailing-spaces) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+
+# remove-trailing-spaces [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/remove-trailing-spaces.svg)](https://travis-ci.org/IonicaBizau/remove-trailing-spaces/) [![Version](https://img.shields.io/npm/v/remove-trailing-spaces.svg)](https://www.npmjs.com/package/remove-trailing-spaces) [![Downloads](https://img.shields.io/npm/dt/remove-trailing-spaces.svg)](https://www.npmjs.com/package/remove-trailing-spaces) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Remove the trailing spaces from a string.
 
 ## :cloud: Installation
-    
+
 ```sh
 $ npm i --save remove-trailing-spaces
 ```
 
-            
+
 ## :clipboard: Example
 
-        
+
 
 ```js
 const removeTrailingSpaces = require("remove-trailing-spaces");
@@ -37,9 +38,10 @@ res.split("\n").forEach((c, i) => {
     // Removed 0 spaces on line 6
 });
 ```
-    
+
 ## :memo: Documentation
-        
+
+
 ### `removeTrailingSpaces(input)`
 Remove the trailing spaces from a string.
 
@@ -49,14 +51,21 @@ Remove the trailing spaces from a string.
 #### Return
 - **String** The output string.
 
-        
+
+
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
+## :dizzy: Where is this library used?
+If you are using this library in one of your projects, add it in this list. :sparkles:
+
+
+ - [`write-file-trim`](https://github.com/IonicaBizau/write-file-trim#readme)—Write the content in a file after removing the trailing spaces.
+
 ## :scroll: License
-    
+
 [MIT][license] © [Ionică Bizău][website]
-    
+
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "string"
   ],
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "scripts": {
     "test": "node test"
@@ -27,5 +27,16 @@
   "homepage": "https://github.com/IonicaBizau/remove-trailing-spaces#readme",
   "devDependencies": {
     "tester": "^1.3.1"
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
